### PR TITLE
Fix telegram bot updater attribute error

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,8 +35,8 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 from telegram import Update
-from telegram.ext import (ApplicationBuilder, CommandHandler,
-                          ContextTypes, JobQueue)
+from telegram.ext import (Application, CommandHandler,
+                          ContextTypes)
 
 
 # Read the bot token from the environment. You must set this in
@@ -99,7 +99,7 @@ async def start_session(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         for job in session_jobs:
             job.schedule_removal()
 
-    job_queue: JobQueue = context.job_queue
+    job_queue = context.job_queue
 
     # Helper function to schedule a reminder
     def schedule_reminder(minutes_left: int):
@@ -183,7 +183,8 @@ def main() -> None:
 
     logger.info("Bot starting up")
 
-    application = ApplicationBuilder().token(TELEGRAM_BOT_TOKEN).build()
+    # Create the Application using the builder pattern (v20+ style)
+    application = Application.builder().token(TELEGRAM_BOT_TOKEN).build()
 
     # Register command handlers
     application.add_handler(CommandHandler("start", start_command))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 
-python-telegram-bot==20.8
+python-telegram-bot[job-queue]==21.9
 
 


### PR DESCRIPTION
<!-- Update python-telegram-bot to v21.9 and adjust API usage to fix `AttributeError`. -->

<!-- The `AttributeError: 'Updater' object has no attribute '_Updater__polling_cleanup_cb'` was caused by a compatibility issue between `python-telegram-bot` v20.8 and the `ApplicationBuilder` class. Version 20+ introduced `__slots__` which prevented setting certain attributes. Updating to v21.9 and using `Application.builder()` resolves this. -->

---

[Open in Web](https://www.cursor.com/agents?id=bc-c516edd0-0947-4e50-bcc5-6113a5fc266e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-c516edd0-0947-4e50-bcc5-6113a5fc266e)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)