### PR TITLE
Convert bot to on-demand web service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Claude Session Alert Bot
+
+בוט טלגרם שמזכיר למשתמש 10 ו-5 דקות לפני סיום שיחה עם Claude.
+
+## שינויים חדשים - Web Service
+
+הבוט שונה מ-background worker ל-web service שיישן עד שיקבל פקודה מהמשתמש.
+
+### מה השתנה:
+
+1. **Web Service במקום Worker**: הבוט כעת רץ כ-web service עם Flask
+2. **Webhook במקום Polling**: הבוט מקבל עדכונים דרך webhook מטלגרם במקום polling מתמיד
+3. **חיסכון במשאבים**: הבוט יישן כאשר אין פעילות ויתעורר רק כשמגיעה פקודה
+
+### הגדרה:
+
+1. הגדר את משתני הסביבה:
+   - `TELEGRAM_BOT_TOKEN`: טוקן הבוט מ-BotFather
+   - `WEBHOOK_URL`: כתובת השירות (לדוגמה: https://your-app.onrender.com)
+
+2. הבוט יגדיר אוטומטית webhook ב-Telegram
+
+### Endpoints:
+
+- `/webhook` - מקבל עדכונים מטלגרם
+- `/health` - בדיקת בריאות השירות
+- `/` - עמוד בית פשוט
+
+### פקודות:
+
+- `/start` - הודעת ברוכים הבאים
+- `/start_session <דקות>` - התחלת מעקב שיחה
+
+### דוגמה:
+```
+/start_session 30
+```
+יתחיל מעקב של 30 דקות עם התראות ב-20 ו-25 דקות.

--- a/render.yaml
+++ b/render.yaml
@@ -1,5 +1,5 @@
 services:
-  - type: worker
+  - type: web
     name: claude-token-alert-bot
     env: python
     region: oregon  # default region; adjust as needed
@@ -10,3 +10,5 @@ services:
     envVars:
       - key: TELEGRAM_BOT_TOKEN
         sync: true
+      - key: WEBHOOK_URL
+        value: https://claude-token-alert-bot.onrender.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 
 python-telegram-bot[job-queue]==21.9
+flask==3.0.0
 
 


### PR DESCRIPTION
Convert the bot from a background worker to a web service to enable resource-saving sleep mode and faster webhook responses.

---

[Open in Web](https://www.cursor.com/agents?id=bc-95b4e66a-a8cd-4d8a-8268-35f0c5d13d33) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-95b4e66a-a8cd-4d8a-8268-35f0c5d13d33)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)